### PR TITLE
Fix typed property being accessed before init

### DIFF
--- a/src/GitWrapper.php
+++ b/src/GitWrapper.php
@@ -182,7 +182,7 @@ final class GitWrapper
 
         if (! $streamOutput && $this->outputEventSubscriber !== null) {
             $this->removeOutputEventSubscriber($this->outputEventSubscriber);
-            unset($this->outputEventSubscriber);
+            $this->outputEventSubscriber = null;
         }
     }
 


### PR DESCRIPTION
Currently, the following code:

```
$gitWrapper = new GitWrapper(...);
$gitWrapper->streamOutput(false);
$gitWrapper->streamOutput();
```

will result in:

`Typed property Symplify\GitWrapper\GitWrapper::$outputEventSubscriber must not be accessed before initialization`.

This is because the property was being `unset()` when calling `GitWrapper::streamOutput(false)`.